### PR TITLE
Add `package: write` for `ghcr.io` permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ env:
 permissions:
   id-token: write
   contents: read
+  packages: write
 
 jobs:
   base:


### PR DESCRIPTION
## Description of the change

Fixing this issue:

```
#16 [auth] spacelift-io/runner-ansible:pull,push token for ghcr.io
#16 DONE 0.0s

#14 exporting to image
#14 pushing layers 0.8s done
#14 ERROR: unexpected status: 403 Forbidden
------
 > exporting to image:
------
ERROR: failed to solve: unexpected status: 403 Forbidden
Error: buildx failed with: ERROR: failed to solve: unexpected status: 403 Forbidden
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [ ] Parts of this pull request impacting core (user-facing, documented) product functionality have test coverage;

### Code review

- [ ] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer a draft;
- [ ] You have reviewed this Pull Request yourself;
