### PR TITLE
feat: Upgrade ansible to 10

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@ FROM public.ecr.aws/spacelift/runner-terraform
 USER root
 WORKDIR /home/spacelift
 
-# Pinning to 7 for now, will introduce more tags a bit later
+# Its been a while! Upgrading to 10, will introduce more tags a bit later
 
 RUN apk -U upgrade && apk add --no-cache gcc py3-pip python3-dev musl-dev libffi-dev && \
   pip install ansible==10.* ansible-runner==2.* --break-system-packages && \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/spacelift
 # Pinning to 7 for now, will introduce more tags a bit later
 
 RUN apk -U upgrade && apk add --no-cache gcc py3-pip python3-dev musl-dev libffi-dev && \
-  pip install ansible==7.* ansible-runner==2.* --break-system-packages && \
+  pip install ansible==10.* ansible-runner==2.* --break-system-packages && \
   apk del python3-dev gcc musl-dev libffi-dev
 
 USER spacelift


### PR DESCRIPTION
## Description of the change

This would upgrade ansible to 10 as there are bugs with the existing system.
A popular usecase : https://github.com/ansible/ansible/pull/80751
A very low level demonstration of the bug
```
$ ansible-galaxy collection install community.docker
Starting galaxy collection install process
Process install dependency map
[WARNING]: Skipping Galaxy server https://galaxy.ansible.com. Got an unexpected error when getting available versions of collection community.docker: Unknown error when
attempting to call Galaxy at 'https://galaxy.ansible.com/api/': HTTPSConnection.__init__() got an unexpected keyword argument 'cert_file'. HTTPSConnection.__init__() got an
unexpected keyword argument 'cert_file'
ERROR! Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': HTTPSConnection.__init__() got an unexpected keyword argument 'cert_file'. HTTPSConnection.__init__() got an unexpected keyword argument 'cert_file'
```

There are two ways to fix, either to switch to python 3.11 or upgrade ansible and I would prefer to upgrade ansible.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [ ] Parts of this pull request impacting core (user-facing, documented) product functionality have test coverage;

### Code review

- [ ] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer a draft;
- [ ] You have reviewed this Pull Request yourself;
