### PR TITLE
feat: add latest tag to newest major version

### DIFF
--- a/build-matrix/main.go
+++ b/build-matrix/main.go
@@ -49,7 +49,6 @@ func main() {
 	}
 
 	matrixOutput := GenerateBuildMatrix(resp.Body, minSupportedMajor)
-
 	output, err := json.Marshal(matrixOutput)
 	if err != nil {
 		log.Fatal(err)
@@ -99,7 +98,7 @@ func GenerateBuildMatrix(reader io.Reader, minSupportedMajor uint64) Matrix {
 
 	minorVersionDeduplication := map[string]any{}
 	matrix := Matrix{}
-	for _, majorVersion := range majorVersions {
+	for j, majorVersion := range majorVersions {
 		for i, version := range versionGroupedByMajor[majorVersion] {
 			key := fmt.Sprintf("%d.%d", version.Major(), version.Minor())
 			if _, exists := minorVersionDeduplication[key]; exists {
@@ -108,7 +107,11 @@ func GenerateBuildMatrix(reader io.Reader, minSupportedMajor uint64) Matrix {
 			additionalTags := make([]string, 0)
 			if i == 0 {
 				additionalTags = append(additionalTags, fmt.Sprintf("%d", version.Major()))
+				if j == 0 {
+					additionalTags = append(additionalTags, "latest")
+				}
 			}
+
 			minorVersionDeduplication[key] = struct{}{}
 			matrix = append(matrix, matrixVersion{
 				Ansible:        key,

--- a/build-matrix/main_test.go
+++ b/build-matrix/main_test.go
@@ -34,7 +34,7 @@ func TestGenerateBuildMatrix(t *testing.T) {
 	expectedMatrix := Matrix{
 		{
 			Ansible:        "3.6",
-			AdditionalTags: []string{"3"},
+			AdditionalTags: []string{"3", "latest"},
 		},
 		{
 			Ansible:        "3.5",


### PR DESCRIPTION
## Description of the change

This change adds support for automatically applying the "latest" tag to the newest major version of releases. This enhancement improves version management by ensuring users can easily identify and reference the most current major release version.

This PR can lead to potentially disruption in user flow.

**TO BE MERGED NO SOONER THAN JULY 21st 2025**

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [ ] Parts of this pull request impacting core (user-facing, documented) product functionality have test coverage;

### Code review

- [ ] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer a draft;
- [ ] You have reviewed this Pull Request yourself;