### PR TITLE
Refactor Docker workflows to support multiple base images

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,12 +2,11 @@ name: Deploy docker images
 on:
   workflow_call:
     inputs:
-      matrix:
+      versions:
         required: true
         type: string
-      target_tag_postfix:
-        required: false
-        default: ''
+      base_image:
+        required: true
         type: string
 
 jobs:
@@ -24,7 +23,14 @@ jobs:
           - aws
           - gcp
           - azure
-        versions: ${{ fromJson(inputs.matrix) }}
+        base_image:
+          - name: ${{ inputs.base_image }}
+            tag_suffix: ""
+          - name: python:3.11-alpine
+            tag_suffix: "-python-3.11"
+          - name: spacelift-io/alpine-fips:python-latest
+            tag_suffix: "-fips"
+        versions: ${{ fromJson(inputs.versions) }}
     permissions:
       id-token: write
       packages: write
@@ -33,19 +39,19 @@ jobs:
       - name: Download ${{ matrix.target }}/amd64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64${{ inputs.target_tag_postfix }}
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64${{ matrix.base_image.tag_suffix }}
           path: '/tmp'
 
       - name: Download ${{ matrix.target }}/arm64 artifact
         uses: actions/download-artifact@v4
         with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64${{ inputs.target_tag_postfix }}
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64${{ matrix.base_image.tag_suffix }}
           path: '/tmp'
 
       - name: Load image
         run: |
-          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64.tar
-          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64.tar
+          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64${{ matrix.base_image.tag_suffix }}.tar
+          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64${{ matrix.base_image.tag_suffix }}.tar
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -69,57 +75,57 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Push images ${{ matrix.versions.ansible }}/${{ matrix.target }}
+      - name: Push images ${{ matrix.versions.ansible }}/${{ matrix.target }}${{ matrix.base_image.tag_suffix }}
         working-directory: .github/scripts
         env:
           ECR_IMAGE: ${{ secrets.PUBLIC_RUNNER_ANSIBLE_ECR_REPOSITORY_URL }}
-          TARGET_TAG: -${{ matrix.target }}${{ inputs.target_tag_postfix }}
+          TARGET_TAG: -${{ matrix.target }}${{ matrix.base_image.tag_suffix }}
         run: |
           if [[ "${TARGET_TAG}" == "-base" ]]; then
-            TARGET_TAG=""${{ inputs.target_tag_postfix }}
+            TARGET_TAG=""
           fi
 
           # Push ECR amd64 tag
-          ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-${{ github.sha }}\
+          ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64${{ matrix.base_image.tag_suffix }}-${{ github.sha }}\
             ${{ env.ECR_IMAGE }}:${{ matrix.versions.ansible }}${TARGET_TAG}-linux-amd64
 
           # Push ECR amd64 additional tags
           for tag in ${{ join(matrix.versions.additional_tags, ' ') }}
           do
-            ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-${{ github.sha }}\
+            ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64${{ matrix.base_image.tag_suffix }}-${{ github.sha }}\
                 ${{ env.ECR_IMAGE }}:${tag}${TARGET_TAG}-linux-amd64
           done
 
           # Push ECR arm64 tags
-          ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-${{ github.sha }}\
+          ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64${{ matrix.base_image.tag_suffix }}-${{ github.sha }}\
             ${{ env.ECR_IMAGE }}:${{ matrix.versions.ansible }}${TARGET_TAG}-linux-arm64
 
           # Push ECR amd64 additional tags
           for tag in ${{ join(matrix.versions.additional_tags, ' ') }}
           do
-            ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-${{ github.sha }}\
+            ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64${{ matrix.base_image.tag_suffix }}-${{ github.sha }}\
                 ${{ env.ECR_IMAGE }}:${tag}${TARGET_TAG}-linux-arm64
           done
 
           # Push ghcr amd64 tags
-          ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-${{ github.sha }}\
+          ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64${{ matrix.base_image.tag_suffix }}-${{ github.sha }}\
             ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}${TARGET_TAG}-linux-amd64
 
           # Push ghcr amd64 additional tags
           for tag in ${{ join(matrix.versions.additional_tags, ' ') }}
           do
-            ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-${{ github.sha }}\
+            ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64${{ matrix.base_image.tag_suffix }}-${{ github.sha }}\
               ghcr.io/${{ github.repository }}:${tag}${TARGET_TAG}-linux-amd64
           done
 
           # Push ghcr arm64 tags
-          ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-${{ github.sha }}\
+          ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64${{ matrix.base_image.tag_suffix }}-${{ github.sha }}\
             ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}${TARGET_TAG}-linux-arm64
 
           # Push ghcr arm64 additional tags
           for tag in ${{ join(matrix.versions.additional_tags, ' ') }}
           do
-            ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-${{ github.sha }}\
+            ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64${{ matrix.base_image.tag_suffix }}-${{ github.sha }}\
               ghcr.io/${{ github.repository }}:${tag}${TARGET_TAG}-linux-arm64
           done
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,6 @@
 name: Build docker images
+env:
+  BASE_IMAGE: python:3.12-alpine
 on:
   push:
   schedule:
@@ -32,6 +34,11 @@ jobs:
           MATRIX=$(go run ./)
           echo ${MATRIX} | jq
           echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
+
+      - name: Print base image
+        id: base_image
+        run: echo "base_image=${{ env.BASE_IMAGE }}" >> $GITHUB_OUTPUT
+
   build:
     needs: [ matrix ]
     runs-on: ubuntu-latest
@@ -47,6 +54,13 @@ jobs:
           - aws
           - gcp
           - azure
+        base_image:
+          - name: ${{ needs.base_image.outputs.base_image }}
+            tag_suffix: ""
+          - name: python:3.11-alpine
+            tag_suffix: "-python-3.11"
+          - name: spacelift-io/alpine-fips:python-latest
+            tag_suffix: "-fips"
         platform:
           - linux/amd64
           - linux/arm64
@@ -75,41 +89,21 @@ jobs:
           target: ${{ matrix.target }}
           build-args: |
             ANSIBLE_VERSION=${{ matrix.versions.ansible }}
+            BASE_IMAGE=${{ matrix.base_image.name }}
           platforms: ${{ matrix.platform }}
-          outputs: type=docker,dest=/tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
-          tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-${{ github.sha }}
-
-      - name: Build Docker fips images
-        uses: docker/build-push-action@v6
-        id: build-fips
-        with:
-          pull: true
-          target: ${{ matrix.target }}
-          build-args: |
-            ANSIBLE_VERSION=${{ matrix.versions.ansible }}
-            BASE_IMAGE=ghcr.io/spacelift-io/alpine-fips:python-latest
-          platforms: ${{ matrix.platform }}
-          outputs: type=docker,dest=/tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
-          tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}${{ matrix.base_image.tag_suffix }}.tar
+          tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}${{ matrix.base_image.tag_suffix }}-${{ github.sha }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
-          path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Upload fips artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips
-          path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}${{ matrix.base_image.tag_suffix }}
+          path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}${{ matrix.base_image.tag_suffix }}.tar
           retention-days: 1
           if-no-files-found: error
 
   test:
-    name: Test image ${{ matrix.versions.ansible }}-${{ matrix.target }}/${{ matrix.platform }}
+    name: Test image ${{ matrix.versions.ansible }}-${{ matrix.target }}/${{ matrix.platform }}${{ matrix.base_image.tag_suffix }}
     needs: [ matrix, build ]
     runs-on: ubuntu-latest
     strategy:
@@ -120,6 +114,13 @@ jobs:
           - aws
           - gcp
           - azure
+        base_image:
+          - name: ${{ needs.base_image.outputs.base_image }}
+            tag_suffix: ""
+          - name: python:3.11-alpine
+            tag_suffix: "-python-3.11"
+          - name: spacelift-io/alpine-fips:python-latest
+            tag_suffix: "-fips"
         platform:
           - linux/amd64
         versions: ${{ fromJson(needs.matrix.outputs.matrix) }}
@@ -129,16 +130,16 @@ jobs:
           platform=${{ matrix.platform }}
           export PLATFORM_PAIR=${platform//\//-}
           echo "PLATFORM_PAIR=${PLATFORM_PAIR}" >> $GITHUB_ENV
-          echo "IMAGE=ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${PLATFORM_PAIR}-${{ github.sha }}" >> $GITHUB_ENV
+          echo "IMAGE=ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${PLATFORM_PAIR}${{ matrix.base_image.tag_suffix }}-${{ github.sha }}" >> $GITHUB_ENV
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}${{ matrix.base_image.tag_suffix }}
           path: /tmp
 
       - name: Load image
         run: |
-          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
+          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}${{ matrix.base_image.tag_suffix }}.tar
           docker image ls -a
 
       - name: Test ansible version
@@ -164,97 +165,26 @@ jobs:
         if: matrix.target == 'azure'
         run: |
           docker run --rm ${{ env.IMAGE }} az --version
-
-  test-fips:
-    name: Test image ${{ matrix.versions.ansible }}-${{ matrix.target }}/${{ matrix.platform }}
-    needs: [ matrix, build ]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - base
-          - aws
-          - gcp
-          - azure
-        platform:
-          - linux/amd64
-        versions: ${{ fromJson(needs.matrix.outputs.matrix) }}
-    steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          export PLATFORM_PAIR=${platform//\//-}
-          echo "PLATFORM_PAIR=${PLATFORM_PAIR}" >> $GITHUB_ENV
-          echo "IMAGE=ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${PLATFORM_PAIR}-${{ github.sha }}" >> $GITHUB_ENV
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips
-          path: /tmp
-
-      - name: Load image
-        run: |
-          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
-          docker image ls -a
-
-      - name: Test ansible version
-        run: |
-          docker run --rm ${{ env.IMAGE }} ansible-community --version | grep 'Ansible community version ${{ matrix.versions.ansible }}'
-          docker run --rm ${{ env.IMAGE }} ansible --version
-          docker run --rm ${{ env.IMAGE }} ansible-playbook --version
-          docker run --rm ${{ env.IMAGE }} ansible-galaxy --version
-          docker run --rm ${{ env.IMAGE }} ansible-runner --version
-          docker run --rm ${{ env.IMAGE }} ansible-galaxy collection list
 
       - name: Test fips
+        if: matrix.base_image.tag_suffix == '-fips'
         run: |
           docker run --rm ${{ env.IMAGE }} sh -c '[ -n "$OPENSSL_FIPS" ] || exit 1'
-
-      - name: Test aws flavor
-        if: matrix.target == 'aws'
-        run: |
-          docker run --rm ${{ env.IMAGE }} sh -c "python3 -c \"import boto3; print(boto3.__version__)\""
-
-      - name: Test gcp flavor
-        if: matrix.target == 'gcp'
-        run: |
-          docker run --rm ${{ env.IMAGE }} sh -c "python3 -c \"import google.auth; print(google.auth.__version__)\""
-
-      - name: Test azure flavor
-        if: matrix.target == 'azure'
-        run: |
-          docker run --rm ${{ env.IMAGE }} az --version
 
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: [ matrix, test ]
     uses: ./.github/workflows/deploy.yaml
     with:
-      matrix: ${{ needs.matrix.outputs.matrix }}
-    secrets: inherit
-
-  deploy-fips:
-    if: github.ref == 'refs/heads/main'
-    needs: [ matrix, test ]
-    uses: ./.github/workflows/deploy.yaml
-    with:
-      matrix: ${{ needs.matrix.outputs.matrix }}
-      target_tag_postfix: '-fips'
+      versions: ${{ needs.matrix.outputs.matrix }}
+      base_image: ${{ needs.base_image.outputs.base_image }}
     secrets: inherit
 
   security:
     needs: [ matrix, deploy ]
     uses: ./.github/workflows/security.yaml
     with:
-      matrix: ${{ needs.matrix.outputs.matrix }}
+      versions: ${{ needs.matrix.outputs.matrix }}
+      base_image: ${{ needs.base_image.outputs.base_image }}
     secrets: inherit
 
-
-  security-fips:
-    needs: [ matrix, deploy ]
-    uses: ./.github/workflows/security.yaml
-    with:
-      matrix: ${{ needs.matrix.outputs.matrix }}
-      target_tag_postfix: '-fips'
-    secrets: inherit

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -2,12 +2,11 @@ name: Scan docker images
 on:
   workflow_call:
     inputs:
-      matrix:
+      versions:
         required: true
         type: string
-      target_tag_postfix:
-        required: false
-        default: ''
+      base_image:
+        required: true
         type: string
 
 jobs:
@@ -25,16 +24,23 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-        versions: ${{ fromJson(inputs.matrix) }}
+        base_image:
+          - name: ${{ inputs.base_image }}
+            tag_suffix: ""
+          - name: python:3.11-alpine
+            tag_suffix: "-python-3.11"
+          - name: spacelift-io/alpine-fips:python-latest
+            tag_suffix: "-fips"
+        versions: ${{ fromJson(inputs.versions) }}
     steps:
       - name: Prepare
         env:
-          TARGET_TAG: -${{ matrix.target }}${{ inputs.target_tag_postfix }}
+          TARGET_TAG: -${{ matrix.target }}${{ matrix.base_image.tag_suffix }}
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
           if [[ "${TARGET_TAG}" == "-base" ]]; then
-            TARGET_TAG=""${{ inputs.target_tag_postfix }}
+            TARGET_TAG=""
           fi
           echo "TARGET_TAG=${TARGET_TAG}" >> $GITHUB_ENV
 
@@ -44,14 +50,14 @@ jobs:
           image-ref: "ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}${{ env.TARGET_TAG }}-${{ env.PLATFORM_PAIR }}"
           format: "template"
           template: "@/contrib/sarif.tpl"
-          output: "${{ matrix.target }}${{ inputs.target_tag_postfix }}.sarif"
+          output: "${{ matrix.target }}${{ matrix.base_image.tag_suffix }}.sarif"
           severity: "CRITICAL,HIGH"
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
-      - name: Upload ${{ matrix.target }}${{ inputs.target_tag_postfix }} image scan results to GitHub Security tab
+      - name: Upload ${{ matrix.target }}${{ matrix.base_image.tag_suffix }} image scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
-          category: ${{ matrix.target }}${{ inputs.target_tag_postfix }}
-          sarif_file: "${{ matrix.target }}${{ inputs.target_tag_postfix }}.sarif"
+          category: ${{ matrix.target }}${{ matrix.base_image.tag_suffix }}
+          sarif_file: "${{ matrix.target }}${{ matrix.base_image.tag_suffix }}.sarif"
 


### PR DESCRIPTION
## Summary

- Consolidate FIPS and regular image builds into single matrix strategy
- Add support for Python 3.11 base image alongside Python 3.12
- Simplify deployment workflows by removing duplicate FIPS-specific jobs

## Test plan

- [ ] Verify Docker images build successfully for all base image variants
- [ ] Confirm artifact naming includes proper base image suffixes
- [ ] Test deployment workflow handles matrix correctly
- [ ] Validate security scanning works with new matrix structure