### PR TITLE
build(docker): add g++ compiler to build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY scripts/* /build/
 RUN adduser --disabled-password --uid=1983 spacelift &&\
     apk -U upgrade --available &&\
     # Required to install ansible pip package, bear in mind to remove those build deps at the end of this RUN directive
-    apk add --virtual=build --no-cache --update gcc musl-dev libffi-dev openssl-dev make cmake &&\
+    apk add --virtual=build --no-cache --update gcc g++ musl-dev libffi-dev openssl-dev make cmake &&\
     # Add here package mandatory to be able to run ansible
     apk add --no-cache openssh-client ca-certificates &&\
     # Ensure latest setuptools to override any vulnerable system packages
@@ -39,7 +39,7 @@ RUN pip install --no-cache-dir boto3==1.* &&\
 USER spacelift
 
 FROM ansible AS azure
-RUN apk add --virtual=build --no-cache gcc musl-dev linux-headers make cmake &&\
+RUN apk add --virtual=build --no-cache gcc g++ musl-dev linux-headers make cmake &&\
     # Install azure collection
     /build/install-azure-collection.sh &&\
     pip install --no-cache-dir azure-cli==2.* &&\


### PR DESCRIPTION
## Description of the change

This PR adds the `g++` (C++ compiler) to the Alpine Linux build dependencies in both the `ansible` and `azure` stages of the Dockerfile. While `gcc` provides C compilation, some Python packages installed via pip require C++ compilation capabilities, which necessitates the `g++` compiler.

**Rationale:** Some Python dependencies (particularly those with C++ extensions) require a C++ compiler during wheel building or when compiling from source. Adding `g++` ensures complete build toolchain compatibility and prevents potential build failures for packages with C++ components.

**Changes:**
- Added `g++` to the `ansible` stage build dependencies alongside existing gcc, musl-dev, libffi-dev, openssl-dev, make, and cmake
- Added `g++` to the `azure` stage build dependencies alongside existing gcc, musl-dev, linux-headers, make, and cmake

**Impact:** This change ensures that pip packages requiring C++ compilation can be built successfully during the Docker image build process. The `g++` package is added as a virtual build dependency and will be removed at the end of the RUN directive, keeping the final image size minimal.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Parts of this pull request impacting core (user-facing, documented) product functionality have test coverage;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer a draft;
- [ ] You have reviewed this Pull Request yourself;