### PR TITLE
chore: bump deprecated node20 GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,13 +32,13 @@ jobs:
       contents: read
     steps:
       - name: Download ${{ matrix.target }}/amd64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64${{ inputs.target_tag_postfix }}
           path: '/tmp'
 
       - name: Download ${{ matrix.target }}/arm64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64${{ inputs.target_tag_postfix }}
           path: '/tmp'
@@ -49,7 +49,7 @@ jobs:
           docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64${{ inputs.target_tag_postfix }}.tar
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -61,14 +61,14 @@ jobs:
           REPOSITORY_PATH: ${{ secrets.PUBLIC_RUNNER_ANSIBLE_ECR_REPOSITORY_URL }}
 
       - name: Log in to Github Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Push images ${{ matrix.versions.ansible }}/${{ matrix.target }}
         working-directory: .github/scripts

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,9 +16,9 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: './build-matrix/go.mod'
           cache-dependency-path: './build-matrix/go.mod'
@@ -54,7 +54,7 @@ jobs:
         versions: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Prepare
         run: |
@@ -63,13 +63,13 @@ jobs:
 
       - name: Set up QEMU
         if: matrix.platform == 'linux/arm64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         id: build
         with:
           pull: true
@@ -81,7 +81,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-${{ github.sha }}
 
       - name: Build Docker fips images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         id: build-fips
         with:
           pull: true
@@ -94,7 +94,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-${{ github.sha }}-fips
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
@@ -102,7 +102,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload fips artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips
           path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips.tar
@@ -132,7 +132,7 @@ jobs:
           echo "PLATFORM_PAIR=${PLATFORM_PAIR}" >> $GITHUB_ENV
           echo "IMAGE=ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${PLATFORM_PAIR}-${{ github.sha }}" >> $GITHUB_ENV
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
           path: /tmp
@@ -193,7 +193,7 @@ jobs:
           echo "PLATFORM_PAIR=${PLATFORM_PAIR}" >> $GITHUB_ENV
           echo "IMAGE=ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${PLATFORM_PAIR}-${{ github.sha }}-fips" >> $GITHUB_ENV
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips
           path: /tmp


### PR DESCRIPTION
Bumps GitHub Actions that were using the deprecated Node.js 20 runtime.

## Changes
- `actions/checkout@v4 → actions/checkout@v7`
- `actions/download-artifact@v4 → actions/download-artifact@v8`
- `actions/setup-go@v5 → actions/setup-go@v6`
- `actions/upload-artifact@v4 → actions/upload-artifact@v7`
- `aws-actions/configure-aws-credentials@v4 → aws-actions/configure-aws-credentials@v6`
- `docker/build-push-action@v6 → docker/build-push-action@v7`
- `docker/login-action@v3 → docker/login-action@v4`
- `docker/setup-buildx-action@v3 → docker/setup-buildx-action@v4`
- `docker/setup-qemu-action@v3 → docker/setup-qemu-action@v4`

## Why
Node.js 20 reached EOL in April 2026 and GitHub is deprecating it on Actions runners.
See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> ⚠️ Actions with potentially breaking changes (custom configs, major API changes) are excluded and need manual review.

🤖 Generated with Claude Code
👦🏻 Reviewed by human