### PR TITLE
ci: merge per-platform build jobs and fix deploy gate

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -76,8 +76,8 @@ jobs:
           ECR_IMAGE: ${{ secrets.PUBLIC_RUNNER_ANSIBLE_ECR_REPOSITORY_URL }}
           TARGET_TAG: -${{ matrix.target }}${{ inputs.target_tag_postfix }}
         run: |
-          if [[ "${TARGET_TAG}" == "-base" ]]; then
-            TARGET_TAG=""${{ inputs.target_tag_postfix }}
+          if [[ "${{ matrix.target }}" == "base" ]]; then
+            TARGET_TAG="${{ inputs.target_tag_postfix }}"
           fi
 
           # Push ECR amd64 tag
@@ -95,7 +95,7 @@ jobs:
           ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-${{ github.sha }}${{ inputs.target_tag_postfix }}\
             ${{ env.ECR_IMAGE }}:${{ matrix.versions.ansible }}${TARGET_TAG}-linux-arm64
 
-          # Push ECR amd64 additional tags
+          # Push ECR arm64 additional tags
           for tag in ${{ join(matrix.versions.additional_tags, ' ') }}
           do
             ./retag-and-push.sh ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-${{ github.sha }}${{ inputs.target_tag_postfix }}\

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
   build:
     needs: [ matrix ]
     runs-on: ubuntu-latest
-    name: Build ansible ${{ matrix.versions.ansible }}-${{ matrix.target }}/${{ matrix.platform }}
+    name: Build ansible ${{ matrix.versions.ansible }}-${{ matrix.target }}
     permissions:
       packages: write
       contents: read
@@ -48,69 +48,97 @@ jobs:
           - aws
           - gcp
           - azure
-        platform:
-          - linux/amd64
-          - linux/arm64
         versions: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
 
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
       - name: Set up QEMU
-        if: matrix.platform == 'linux/arm64'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build Docker images
+      - name: Build Docker images (amd64)
         uses: docker/build-push-action@v7
-        id: build
         with:
           pull: true
           target: ${{ matrix.target }}
           build-args: |
             ANSIBLE_VERSION=${{ matrix.versions.ansible }}
-          platforms: ${{ matrix.platform }}
-          outputs: type=docker,dest=/tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
-          tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-${{ github.sha }}
+          platforms: linux/amd64
+          outputs: type=docker,dest=/tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64.tar
+          tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-${{ github.sha }}
 
-      - name: Build Docker fips images
+      - name: Build Docker images (arm64)
         uses: docker/build-push-action@v7
-        id: build-fips
+        with:
+          pull: true
+          target: ${{ matrix.target }}
+          build-args: |
+            ANSIBLE_VERSION=${{ matrix.versions.ansible }}
+          platforms: linux/arm64
+          outputs: type=docker,dest=/tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64.tar
+          tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-${{ github.sha }}
+
+      - name: Build Docker fips images (amd64)
+        uses: docker/build-push-action@v7
         with:
           pull: true
           target: ${{ matrix.target }}
           build-args: |
             ANSIBLE_VERSION=${{ matrix.versions.ansible }}
             BASE_IMAGE=ghcr.io/spacelift-io/alpine-fips:python-latest
-          platforms: ${{ matrix.platform }}
-          outputs: type=docker,dest=/tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips.tar
-          tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-${{ github.sha }}-fips
+          platforms: linux/amd64
+          outputs: type=docker,dest=/tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-fips.tar
+          tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-${{ github.sha }}-fips
 
-      - name: Upload artifact
+      - name: Build Docker fips images (arm64)
+        uses: docker/build-push-action@v7
+        with:
+          pull: true
+          target: ${{ matrix.target }}
+          build-args: |
+            ANSIBLE_VERSION=${{ matrix.versions.ansible }}
+            BASE_IMAGE=ghcr.io/spacelift-io/alpine-fips:python-latest
+          platforms: linux/arm64
+          outputs: type=docker,dest=/tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-fips.tar
+          tags: ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-${{ github.sha }}-fips
+
+      - name: Upload artifact (amd64)
         uses: actions/upload-artifact@v7
         with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
-          path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64
+          path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64.tar
           retention-days: 1
           if-no-files-found: error
 
-      - name: Upload fips artifact
+      - name: Upload artifact (arm64)
         uses: actions/upload-artifact@v7
         with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips
-          path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips.tar
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64
+          path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64.tar
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload fips artifact (amd64)
+        uses: actions/upload-artifact@v7
+        with:
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-fips
+          path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-fips.tar
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload fips artifact (arm64)
+        uses: actions/upload-artifact@v7
+        with:
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-fips
+          path: /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-arm64-fips.tar
           retention-days: 1
           if-no-files-found: error
 
   test:
-    name: Test image ${{ matrix.versions.ansible }}-${{ matrix.target }}/${{ matrix.platform }}
+    name: Test image ${{ matrix.versions.ansible }}-${{ matrix.target }}
     needs: [ matrix, build ]
     runs-on: ubuntu-latest
     strategy:
@@ -121,26 +149,21 @@ jobs:
           - aws
           - gcp
           - azure
-        platform:
-          - linux/amd64
         versions: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          export PLATFORM_PAIR=${platform//\//-}
-          echo "PLATFORM_PAIR=${PLATFORM_PAIR}" >> $GITHUB_ENV
-          echo "IMAGE=ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${PLATFORM_PAIR}-${{ github.sha }}" >> $GITHUB_ENV
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64
           path: /tmp
 
       - name: Load image
         run: |
-          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}.tar
+          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64.tar
           docker image ls -a
+
+      - name: Set IMAGE env
+        run: echo "IMAGE=ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Test ansible version
         run: |
@@ -171,7 +194,7 @@ jobs:
           docker run --rm ${{ env.IMAGE }} az --version
 
   test-fips:
-    name: Test image ${{ matrix.versions.ansible }}-${{ matrix.target }}/${{ matrix.platform }}
+    name: Test fips image ${{ matrix.versions.ansible }}-${{ matrix.target }}
     needs: [ matrix, build ]
     runs-on: ubuntu-latest
     strategy:
@@ -182,26 +205,21 @@ jobs:
           - aws
           - gcp
           - azure
-        platform:
-          - linux/amd64
         versions: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          export PLATFORM_PAIR=${platform//\//-}
-          echo "PLATFORM_PAIR=${PLATFORM_PAIR}" >> $GITHUB_ENV
-          echo "IMAGE=ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-${PLATFORM_PAIR}-${{ github.sha }}-fips" >> $GITHUB_ENV
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips
+          name: ansible-runner-${{ github.sha }}-${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-fips
           path: /tmp
 
       - name: Load image
         run: |
-          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-${{ env.PLATFORM_PAIR }}-fips.tar
+          docker load --input /tmp/${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-fips.tar
           docker image ls -a
+
+      - name: Set IMAGE env
+        run: echo "IMAGE=ghcr.io/${{ github.repository }}:${{ matrix.versions.ansible }}-${{ matrix.target }}-linux-amd64-${{ github.sha }}-fips" >> $GITHUB_ENV
 
       - name: Test ansible version
         run: |
@@ -233,7 +251,7 @@ jobs:
 
   deploy:
     if: github.ref == 'refs/heads/main'
-    needs: [ matrix, test ]
+    needs: [ matrix, test, test-fips ]
     uses: ./.github/workflows/deploy.yaml
     with:
       matrix: ${{ needs.matrix.outputs.matrix }}
@@ -241,7 +259,7 @@ jobs:
 
   deploy-fips:
     if: github.ref == 'refs/heads/main'
-    needs: [ matrix, test ]
+    needs: [ matrix, test, test-fips ]
     uses: ./.github/workflows/deploy.yaml
     with:
       matrix: ${{ needs.matrix.outputs.matrix }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -182,6 +182,7 @@ jobs:
         if: matrix.target == 'aws'
         run: |
           docker run --rm ${{ env.IMAGE }} sh -c "python3 -c \"import boto3; print(boto3.__version__)\""
+          docker run --rm ${{ env.IMAGE }} session-manager-plugin --version
 
       - name: Test gcp flavor
         if: matrix.target == 'gcp'
@@ -238,6 +239,7 @@ jobs:
         if: matrix.target == 'aws'
         run: |
           docker run --rm ${{ env.IMAGE }} sh -c "python3 -c \"import boto3; print(boto3.__version__)\""
+          docker run --rm ${{ env.IMAGE }} session-manager-plugin --version
 
       - name: Test gcp flavor
         if: matrix.target == 'gcp'

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,23 @@ RUN pip install --no-cache-dir requests==2.* google-auth==2.* && \
     spaceforge --version
 USER spacelift
 
+FROM alpine AS ssm-builder
+ARG TARGETARCH
+RUN apk add --no-cache dpkg curl && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+      curl -sL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_arm64/session-manager-plugin.deb" -o session-manager-plugin.deb; \
+    else \
+      curl -sL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o session-manager-plugin.deb; \
+    fi && \
+    dpkg -x session-manager-plugin.deb /ssm
+
 FROM ansible AS aws
-RUN pip install --no-cache-dir boto3==1.* &&\
+ARG TARGETARCH
+COPY --from=ssm-builder /ssm/usr/local/sessionmanagerplugin/bin/session-manager-plugin /usr/local/bin/
+RUN chmod +x /usr/local/bin/session-manager-plugin && \
+    # session-manager-plugin requires gcompat on amd64
+    if [ "$TARGETARCH" = "amd64" ]; then apk add --no-cache gcompat; fi && \
+    pip install --no-cache-dir boto3==1.* &&\
     /build/install-collection.sh 'amazon.aws:>=9.2.0,<10.0.0' && \
     spaceforge --version
 USER spacelift


### PR DESCRIPTION
## Description of the change

Removes the `platform` dimension from the build matrix so both amd64 and arm64 images are built sequentially in a single job per target/version combo. This halves the number of build jobs while preserving the artifact-based flow (no images pushed to GHCR on feature branches).

Adds `session-manager-plugin` (AWS SSM) to the `aws` image via a multi-stage build that downloads the `.deb` from S3 (arch-aware for amd64/arm64). Includes `gcompat` dependency required on amd64 and test coverage in both `test` and `test-fips` jobs.

Additionally fixes:
- `deploy` and `deploy-fips` now depend on `test-fips` — previously fips images could be deployed even if fips tests failed
- Base target tag condition in deploy uses `matrix.target` instead of the composed `TARGET_TAG` value, fixing incorrect tags for base-fips builds (e.g. `<version>-base-fips` → `<version>-fips`)
- Corrected comment typo (`ECR amd64` → `ECR arm64`)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [x] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Parts of this pull request impacting core (user-facing, documented) product functionality have test coverage;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;
- [ ] You have reviewed this Pull Request yourself;